### PR TITLE
fix: 하단 탭바 시스템 네비게이션 영역 겹침 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,18 +2,20 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import store from './src/store';
 import AppInner from './AppInner';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { StyleSheet } from 'react-native';
 import { Colors } from '@styles/theme';
 
 function App() {
   return (
-    //useSelector 사용 위해 Provider로 감싼 후 AppInner.tsx로 이동
-    <SafeAreaView style={styles.container} edges={['top']}>
-      <Provider store={store}>
-        <AppInner />
-      </Provider>
-    </SafeAreaView>
+    <SafeAreaProvider>
+      {/* useSelector 사용 위해 Provider로 감싼 후 AppInner.tsx로 이동 */}
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <Provider store={store}>
+          <AppInner />
+        </Provider>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 }
 

--- a/AppInner.tsx
+++ b/AppInner.tsx
@@ -21,6 +21,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import messaging from '@react-native-firebase/messaging';
 import Index from './src/pages/SignUpFlow/IntroPage';
 import SplashScreen from 'react-native-splash-screen';
@@ -167,6 +168,7 @@ const runWithRetry = async <T,>(
 function AppInner() {
   const dispatch = useAppDispatch();
   const [loading, setLoading] = useState(true); // Redux 상태를 선택
+  const insets = useSafeAreaInsets();
 
   const navigationRef = useRef<NavigationContainerRef<any>>(null);
   const routeNameRef = useRef<string | undefined>(undefined);
@@ -461,6 +463,10 @@ function AppInner() {
               ...getTabScreenOptions(route.name as TabIconKey),
               tabBarStyle: [
                 styles.tabBar,
+                {
+                  height: 60 + insets.bottom,
+                  paddingBottom: 16 + insets.bottom,
+                },
                 isRunningActive ? styles.tabBarLocked : null,
               ],
             })}
@@ -511,9 +517,7 @@ const styles = StyleSheet.create({
     resizeMode: 'contain',
   },
   tabBar: {
-    height: 60,
     paddingTop: 10,
-    paddingBottom: 16,
     backgroundColor: '#fff',
     borderTopWidth: 0.5,
     borderTopColor: '#e5e7eb',


### PR DESCRIPTION
## 🚀 어떤 변경사항이 있나요?

 S22 Ultra 등 제스처 네비게이션 기기에서 하단 탭바가 시스템 네비게이션 영역과 겹쳐 가려지는 문제를 수정했습니다.

  원인
  - SafeAreaProvider가 없어 useSafeAreaInsets가 항상 0을 반환
  - 탭바의 height, paddingBottom이 고정값으로 설정되어 기기별 bottom inset을 반영하지 못함

  수정 내용
  - App.tsx : SafeAreaProvider 추가
  - AppInner.tsx : useSafeAreaInsets로 bottom inset을 읽어 탭바 높이에 동적 반영
## 📋 체크리스트 (Checklist)

- [ ] PR 목표 달성 여부

- [ ] 코드 리뷰를 위한 중요 사항 주석/설명 추가

- [ ] 코딩 컨벤션 준수

- [ ] 테스트 케이스 작성/수정 (필요 시)

- [ ] 스크린샷/GIF 첨부 (UI 변경 있는 경우)

<br>

## 🔗 관련 이슈 (Related Issues)

- 이 PR이 해결하는 이슈 또는 작업이 있는 경우, 여기에 남겨주세요.

Closes #44 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 기기의 안전 영역(노치, 홈 인디케이터 등)을 더 정확히 인식하도록 개선했습니다.
  * 하단 탭 바가 기기 화면 레이아웃에 맞게 적절하게 배치되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->