### PR TITLE
Feature/profile image history

### DIFF
--- a/src/api/profileApi.ts
+++ b/src/api/profileApi.ts
@@ -1,12 +1,19 @@
 import apiClient from './httpClient';
 import type {
   PetUpdateRequest,
+  ProfileImageHistoryItem,
   ProfileImageUploadResponse,
   UserUpdateRequest,
 } from 'types/profile';
+import type { getUserResponse } from 'types/main';
 
-export const updateUserProfile = async (payload: UserUpdateRequest) => {
+export const updateUserProfile = async (payload: UserUpdateRequest): Promise<getUserResponse> => {
   const { data } = await apiClient.patch('/users', payload);
+  return data;
+};
+
+export const getProfileImageHistory = async (): Promise<ProfileImageHistoryItem[]> => {
+  const { data } = await apiClient.get('/users/profile-image/history');
   return data;
 };
 

--- a/src/components/ProfileAvatar.tsx
+++ b/src/components/ProfileAvatar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Image } from 'react-native';
 import { DEFAULT_PROFILE_URL } from '@shared/constants/profileIcons';
 
@@ -8,6 +8,11 @@ interface Props {
 
 export const ProfileAvatar = ({ profileImageUrl }: Props) => {
   const [imageFailed, setImageFailed] = useState(false);
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [profileImageUrl]);
+
   const uri =
     !imageFailed && profileImageUrl ? profileImageUrl : DEFAULT_PROFILE_URL;
 

--- a/src/pages/ProfileImageModal.tsx
+++ b/src/pages/ProfileImageModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Modal,
   View,
@@ -10,7 +10,6 @@ import {
   Alert,
   ActivityIndicator,
 } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useDispatch } from 'react-redux';
 import { launchImageLibrary } from 'react-native-image-picker';
 import { ProfileAvatar } from '@components/ProfileAvatar';
@@ -21,10 +20,15 @@ import {
   SECRET_PRESET_URLS,
   SECRET_TARGET_URL,
 } from '@shared/constants/profileIcons';
-import { requestProfileImageUpload, updateUserProfile } from '@api/profileApi';
+import {
+  requestProfileImageUpload,
+  updateUserProfile,
+  getProfileImageHistory,
+} from '@api/profileApi';
 import { uploadPhoto } from '@api/uploadPhoto';
 import { getUser } from '@api/mainApi';
 import { validateImageAsset } from '@utils/imageUtil';
+import type { ProfileImageHistoryItem } from 'types/profile';
 
 type Props = {
   visible: boolean;
@@ -33,31 +37,15 @@ type Props = {
 };
 
 const SECRET_TAP_REQUIRED = 5;
-const TAP_TIMEOUT = 2000; // ms
+const TAP_TIMEOUT = 2000;
 
-const PROFILE_HISTORY_KEY = 'fitpet:profile:imageHistory';
-const MAX_HISTORY = 10;
+const S3_ORIGIN = 'https://fitpet-bucket.s3.ap-northeast-2.amazonaws.com/';
 
-const loadProfileImageHistory = async (): Promise<string[]> => {
-  try {
-    const raw = await AsyncStorage.getItem(PROFILE_HISTORY_KEY);
-    return raw ? (JSON.parse(raw) as string[]) : [];
-  } catch {
-    return [];
+const extractImageKey = (s3Url: string): string => {
+  if (s3Url.startsWith(S3_ORIGIN)) {
+    return s3Url.slice(S3_ORIGIN.length).split('?')[0];
   }
-};
-
-const addProfileImageToHistory = async (url: string): Promise<void> => {
-  try {
-    const current = await loadProfileImageHistory();
-    const deduped = [url, ...current.filter((u) => u !== url)];
-    await AsyncStorage.setItem(
-      PROFILE_HISTORY_KEY,
-      JSON.stringify(deduped.slice(0, MAX_HISTORY))
-    );
-  } catch {
-    // 이력 저장 실패는 무시
-  }
+  return s3Url;
 };
 
 export default function ProfileImageModal({
@@ -67,25 +55,41 @@ export default function ProfileImageModal({
 }: Props) {
   const dispatch = useDispatch();
   const [selectedUrl, setSelectedUrl] = useState(currentImageUrl);
+  const [selectedKey, setSelectedKey] = useState(() =>
+    extractImageKey(currentImageUrl)
+  );
   const [uploading, setUploading] = useState(false);
-  const [uploadHistory, setUploadHistory] = useState<string[]>([]);
+  const [uploadHistory, setUploadHistory] = useState<ProfileImageHistoryItem[]>(
+    []
+  );
   const [pendingAsset, setPendingAsset] = useState<{
     uri: string;
     type?: string;
   } | null>(null);
+
+  const historyRefreshingRef = useRef(false);
 
   /** 이스터에그 상태 */
   const [secretUnlocked, setSecretUnlocked] = useState(false);
   const [tapCount, setTapCount] = useState(0);
   const [lastTapTime, setLastTapTime] = useState<number | null>(null);
 
-  /** 모달 열릴 때 초기화 및 이력 로드 */
   useEffect(() => {
     if (visible) {
       setSelectedUrl(currentImageUrl);
+      setSelectedKey(extractImageKey(currentImageUrl));
       setTapCount(0);
       setLastTapTime(null);
-      loadProfileImageHistory().then(setUploadHistory);
+      getProfileImageHistory()
+        .then((history) => {
+          setUploadHistory(history);
+          const current = history.find((item) => item.isCurrent);
+          if (current) {
+            setSelectedKey(current.imageKey);
+            setSelectedUrl(current.presignedUrl);
+          }
+        })
+        .catch(() => {});
     }
   }, [visible, currentImageUrl]);
 
@@ -97,6 +101,7 @@ export default function ProfileImageModal({
 
   const handleAvatarPress = (url: string) => {
     setSelectedUrl(url);
+    setSelectedKey(extractImageKey(url));
 
     if (secretUnlocked || url !== SECRET_TARGET_URL) return;
 
@@ -128,12 +133,13 @@ export default function ProfileImageModal({
     onClose();
   };
 
-  /** 프리셋 선택 저장 */
   const handleSave = async () => {
     try {
       setUploading(true);
-      await updateUserProfile({ profileImageUrl: selectedUrl });
-      dispatch(userSlice.actions.updateProfileImageUrl(selectedUrl));
+      const updated = await updateUserProfile({ profileImageKey: selectedKey });
+      dispatch(
+        userSlice.actions.updateProfileImageUrl(updated.profileImageUrl)
+      );
       handleClose();
     } catch {
       Alert.alert('저장 실패', '프로필 이미지를 저장하지 못했어요.');
@@ -142,7 +148,6 @@ export default function ProfileImageModal({
     }
   };
 
-  /** 갤러리에서 사진 선택 → 확인 모달 표시 */
   const handleGalleryUpload = async () => {
     const result = await launchImageLibrary({
       mediaType: 'photo',
@@ -163,7 +168,6 @@ export default function ProfileImageModal({
     setPendingAsset({ uri: asset.uri, type: asset.type });
   };
 
-  /** 확인 모달에서 "사용하기" → 실제 업로드 */
   const handleConfirmUpload = async () => {
     if (!pendingAsset) return;
 
@@ -174,10 +178,8 @@ export default function ProfileImageModal({
         uri: pendingAsset.uri,
         mimeType: pendingAsset.type ?? 'image/jpeg',
       });
-
       const user = await getUser();
       dispatch(userSlice.actions.updateProfileImageUrl(user.profileImageUrl));
-      await addProfileImageToHistory(user.profileImageUrl);
       setPendingAsset(null);
       handleClose();
     } catch {
@@ -187,132 +189,158 @@ export default function ProfileImageModal({
     }
   };
 
+  const handleHistorySelect = (item: ProfileImageHistoryItem) => {
+    setSelectedKey(item.imageKey);
+    setSelectedUrl(item.presignedUrl);
+  };
+
+  const handleHistoryImageError = async () => {
+    if (historyRefreshingRef.current) return;
+    historyRefreshingRef.current = true;
+    try {
+      const history = await getProfileImageHistory();
+      setUploadHistory(history);
+    } catch {
+      // 실패 시 무시
+    } finally {
+      historyRefreshingRef.current = false;
+    }
+  };
+
   return (
     <>
-    <Modal
-      visible={!!pendingAsset}
-      transparent
-      animationType='fade'
-      onRequestClose={() => setPendingAsset(null)}
-    >
-      <View style={styles.confirmBackdrop}>
-        <View style={styles.confirmContainer}>
-          <Text style={styles.confirmTitle}>이 사진으로 설정할까요?</Text>
-          {pendingAsset && (
-            <Image
-              source={{ uri: pendingAsset.uri }}
-              style={styles.confirmPreview}
-              resizeMode='cover'
-            />
-          )}
-          <View style={styles.footer}>
-            <Pressable
-              onPress={() => setPendingAsset(null)}
-              style={styles.cancelBtn}
-              disabled={uploading}
-            >
-              <Text style={styles.cancelText}>다시 선택</Text>
-            </Pressable>
-            <Pressable
-              onPress={handleConfirmUpload}
-              style={styles.saveBtn}
-              disabled={uploading}
-            >
-              {uploading ? (
-                <ActivityIndicator color='#fff' />
-              ) : (
-                <Text style={styles.saveText}>사용하기</Text>
-              )}
-            </Pressable>
-          </View>
-        </View>
-      </View>
-    </Modal>
-
-    <Modal
-      visible={visible}
-      transparent
-      animationType='slide'
-      onRequestClose={handleClose}
-    >
-      <View style={styles.backdrop}>
-        <View style={styles.container}>
-          <Text style={styles.title}>프로필 이미지 선택</Text>
-
-          <Pressable
-            onPress={handleGalleryUpload}
-            style={styles.galleryBtn}
-            disabled={uploading}
-          >
-            <Text style={styles.galleryBtnText}>📷 갤러리에서 선택</Text>
-          </Pressable>
-
-          {uploadHistory.length > 0 && (
-            <View>
-              <Text style={styles.sectionLabel}>내 사진</Text>
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.historyScroll}
+      <Modal
+        visible={!!pendingAsset}
+        transparent
+        animationType='fade'
+        onRequestClose={() => setPendingAsset(null)}
+      >
+        <View style={styles.confirmBackdrop}>
+          <View style={styles.confirmContainer}>
+            <Text style={styles.confirmTitle}>이 사진으로 설정할까요?</Text>
+            {pendingAsset && (
+              <Image
+                source={{ uri: pendingAsset.uri }}
+                style={styles.confirmPreview}
+                resizeMode='cover'
+              />
+            )}
+            <View style={styles.footer}>
+              <Pressable
+                onPress={() => setPendingAsset(null)}
+                style={styles.cancelBtn}
+                disabled={uploading}
               >
-                {uploadHistory.map((url) => {
-                  const selected = url === selectedUrl;
-                  return (
-                    <Pressable
-                      key={url}
-                      onPress={() => setSelectedUrl(url)}
-                      style={[styles.avatarWrapper, selected && styles.selected]}
-                    >
-                      <ProfileAvatar profileImageUrl={url} />
-                    </Pressable>
-                  );
-                })}
-              </ScrollView>
+                <Text style={styles.cancelText}>다시 선택</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleConfirmUpload}
+                style={styles.saveBtn}
+                disabled={uploading}
+              >
+                {uploading ? (
+                  <ActivityIndicator color='#fff' />
+                ) : (
+                  <Text style={styles.saveText}>사용하기</Text>
+                )}
+              </Pressable>
             </View>
-          )}
-
-          <Text style={styles.sectionLabel}>기본 프로필</Text>
-          <FlatList
-            data={imageList}
-            numColumns={3}
-            keyExtractor={(item) => item}
-            columnWrapperStyle={styles.row}
-            renderItem={({ item }) => {
-              const selected = item === selectedUrl;
-              return (
-                <Pressable
-                  onPress={() => handleAvatarPress(item)}
-                  style={[styles.avatarWrapper, selected && styles.selected]}
-                >
-                  <ProfileAvatar profileImageUrl={item} />
-                </Pressable>
-              );
-            }}
-          />
-
-          <View style={styles.footer}>
-            <Pressable
-              onPress={handleClose}
-              style={styles.cancelBtn}
-              disabled={uploading}
-            >
-              <Text style={styles.cancelText}>취소</Text>
-            </Pressable>
-            <Pressable
-              onPress={handleSave}
-              style={styles.saveBtn}
-              disabled={uploading}
-            >
-              {uploading ? (
-                <ActivityIndicator color='#fff' />
-              ) : (
-                <Text style={styles.saveText}>저장</Text>
-              )}
-            </Pressable>
           </View>
         </View>
-      </View>
-    </Modal>
+      </Modal>
+
+      <Modal
+        visible={visible}
+        transparent
+        animationType='slide'
+        onRequestClose={handleClose}
+      >
+        <View style={styles.backdrop}>
+          <View style={styles.container}>
+            <Text style={styles.title}>프로필 이미지 선택</Text>
+
+            <Pressable
+              onPress={handleGalleryUpload}
+              style={styles.galleryBtn}
+              disabled={uploading}
+            >
+              <Text style={styles.galleryBtnText}>📷 갤러리에서 선택</Text>
+            </Pressable>
+
+            {uploadHistory.length > 0 && (
+              <View>
+                <Text style={styles.sectionLabel}>내 사진</Text>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.historyScroll}
+                >
+                  {uploadHistory.map((item) => {
+                    const selected = item.imageKey === selectedKey;
+                    return (
+                      <Pressable
+                        key={item.imageKey}
+                        onPress={() => handleHistorySelect(item)}
+                        style={[
+                          styles.avatarWrapper,
+                          selected && styles.selected,
+                        ]}
+                      >
+                        <Image
+                          source={{ uri: item.presignedUrl }}
+                          style={{ width: '100%', height: '100%' }}
+                          resizeMode='cover'
+                          onError={handleHistoryImageError}
+                        />
+                      </Pressable>
+                    );
+                  })}
+                </ScrollView>
+              </View>
+            )}
+
+            <Text style={styles.sectionLabel}>기본 프로필</Text>
+            <FlatList
+              data={imageList}
+              numColumns={3}
+              keyExtractor={(item) => item}
+              columnWrapperStyle={styles.row}
+              renderItem={({ item }) => {
+                const selected = extractImageKey(item) === selectedKey;
+                return (
+                  <Pressable
+                    onPress={() => handleAvatarPress(item)}
+                    style={[styles.avatarWrapper, selected && styles.selected]}
+                  >
+                    <ProfileAvatar profileImageUrl={item} />
+                  </Pressable>
+                );
+              }}
+            />
+
+            <View style={styles.footer}>
+              <Pressable
+                onPress={handleClose}
+                style={styles.cancelBtn}
+                disabled={uploading}
+              >
+                <Text style={styles.cancelText}>취소</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleSave}
+                style={styles.saveBtn}
+                disabled={uploading}
+              >
+                {uploading ? (
+                  <ActivityIndicator color='#fff' />
+                ) : (
+                  <Text style={styles.saveText}>저장</Text>
+                )}
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </>
   );
 }

--- a/src/pages/ProfileImageModal.tsx
+++ b/src/pages/ProfileImageModal.tsx
@@ -82,14 +82,18 @@ export default function ProfileImageModal({
       setLastTapTime(null);
       getProfileImageHistory()
         .then((history) => {
+          console.log('[ProfileImage] 이력 조회 성공:', history.length, '개');
           setUploadHistory(history);
           const current = history.find((item) => item.isCurrent);
           if (current) {
+            console.log('[ProfileImage] 현재 프로필 key:', current.imageKey);
             setSelectedKey(current.imageKey);
             setSelectedUrl(current.presignedUrl);
           }
         })
-        .catch(() => {});
+        .catch((e) => {
+          console.warn('[ProfileImage] 이력 조회 실패:', e);
+        });
     }
   }, [visible, currentImageUrl]);
 
@@ -100,8 +104,10 @@ export default function ProfileImageModal({
   }, [secretUnlocked]);
 
   const handleAvatarPress = (url: string) => {
+    const key = extractImageKey(url);
+    console.log('[ProfileImage] 프리셋 선택 → key:', key);
     setSelectedUrl(url);
-    setSelectedKey(extractImageKey(url));
+    setSelectedKey(key);
 
     if (secretUnlocked || url !== SECRET_TARGET_URL) return;
 
@@ -136,12 +142,20 @@ export default function ProfileImageModal({
   const handleSave = async () => {
     try {
       setUploading(true);
-      const updated = await updateUserProfile({ profileImageKey: selectedKey });
-      dispatch(
-        userSlice.actions.updateProfileImageUrl(updated.profileImageUrl)
-      );
+      console.log('[ProfileImage] 저장 요청 → profileImageKey:', selectedKey);
+      await updateUserProfile({ profileImageKey: selectedKey });
+      const history = await getProfileImageHistory();
+      const current = history.find((item) => item.isCurrent);
+      if (current) {
+        console.log(
+          '[ProfileImage] 저장 성공 → presignedUrl:',
+          current.presignedUrl
+        );
+        dispatch(userSlice.actions.updateProfileImageUrl(current.presignedUrl));
+      }
       handleClose();
-    } catch {
+    } catch (e) {
+      console.warn('[ProfileImage] 저장 실패:', e);
       Alert.alert('저장 실패', '프로필 이미지를 저장하지 못했어요.');
     } finally {
       setUploading(false);
@@ -173,16 +187,24 @@ export default function ProfileImageModal({
 
     try {
       setUploading(true);
-      const { uploadUrl } = await requestProfileImageUpload();
+      console.log('[ProfileImage] 갤러리 업로드 시작');
+      const { uploadUrl, imageKey } = await requestProfileImageUpload();
+      console.log('[ProfileImage] presigned URL 발급 → imageKey:', imageKey);
       await uploadPhoto(uploadUrl, {
         uri: pendingAsset.uri,
         mimeType: pendingAsset.type ?? 'image/jpeg',
       });
+      console.log('[ProfileImage] S3 업로드 성공');
       const user = await getUser();
+      console.log(
+        '[ProfileImage] 유저 정보 갱신 → profileImageUrl:',
+        user.profileImageUrl
+      );
       dispatch(userSlice.actions.updateProfileImageUrl(user.profileImageUrl));
       setPendingAsset(null);
       handleClose();
-    } catch {
+    } catch (e) {
+      console.warn('[ProfileImage] 업로드 실패:', e);
       Alert.alert('업로드 실패', '이미지를 업로드하지 못했어요.');
     } finally {
       setUploading(false);
@@ -190,18 +212,21 @@ export default function ProfileImageModal({
   };
 
   const handleHistorySelect = (item: ProfileImageHistoryItem) => {
+    console.log('[ProfileImage] 이력 이미지 선택 → key:', item.imageKey);
     setSelectedKey(item.imageKey);
     setSelectedUrl(item.presignedUrl);
   };
 
   const handleHistoryImageError = async () => {
     if (historyRefreshingRef.current) return;
+    console.log('[ProfileImage] 이력 이미지 로드 실패 → presigned URL 재조회');
     historyRefreshingRef.current = true;
     try {
       const history = await getProfileImageHistory();
+      console.log('[ProfileImage] 이력 재조회 성공:', history.length, '개');
       setUploadHistory(history);
-    } catch {
-      // 실패 시 무시
+    } catch (e) {
+      console.warn('[ProfileImage] 이력 재조회 실패:', e);
     } finally {
       historyRefreshingRef.current = false;
     }

--- a/src/pages/ProfileImageModal.tsx
+++ b/src/pages/ProfileImageModal.tsx
@@ -86,7 +86,6 @@ export default function ProfileImageModal({
           setUploadHistory(history);
           const current = history.find((item) => item.isCurrent);
           if (current) {
-            console.log('[ProfileImage] 현재 프로필 key:', current.imageKey);
             setSelectedKey(current.imageKey);
             setSelectedUrl(current.presignedUrl);
           }
@@ -105,7 +104,6 @@ export default function ProfileImageModal({
 
   const handleAvatarPress = (url: string) => {
     const key = extractImageKey(url);
-    console.log('[ProfileImage] 프리셋 선택 → key:', key);
     setSelectedUrl(url);
     setSelectedKey(key);
 
@@ -142,15 +140,10 @@ export default function ProfileImageModal({
   const handleSave = async () => {
     try {
       setUploading(true);
-      console.log('[ProfileImage] 저장 요청 → profileImageKey:', selectedKey);
       await updateUserProfile({ profileImageKey: selectedKey });
       const history = await getProfileImageHistory();
       const current = history.find((item) => item.isCurrent);
       if (current) {
-        console.log(
-          '[ProfileImage] 저장 성공 → presignedUrl:',
-          current.presignedUrl
-        );
         dispatch(userSlice.actions.updateProfileImageUrl(current.presignedUrl));
       }
       handleClose();
@@ -189,17 +182,12 @@ export default function ProfileImageModal({
       setUploading(true);
       console.log('[ProfileImage] 갤러리 업로드 시작');
       const { uploadUrl, imageKey } = await requestProfileImageUpload();
-      console.log('[ProfileImage] presigned URL 발급 → imageKey:', imageKey);
       await uploadPhoto(uploadUrl, {
         uri: pendingAsset.uri,
         mimeType: pendingAsset.type ?? 'image/jpeg',
       });
       console.log('[ProfileImage] S3 업로드 성공');
       const user = await getUser();
-      console.log(
-        '[ProfileImage] 유저 정보 갱신 → profileImageUrl:',
-        user.profileImageUrl
-      );
       dispatch(userSlice.actions.updateProfileImageUrl(user.profileImageUrl));
       setPendingAsset(null);
       handleClose();
@@ -212,7 +200,6 @@ export default function ProfileImageModal({
   };
 
   const handleHistorySelect = (item: ProfileImageHistoryItem) => {
-    console.log('[ProfileImage] 이력 이미지 선택 → key:', item.imageKey);
     setSelectedKey(item.imageKey);
     setSelectedUrl(item.presignedUrl);
   };

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -108,8 +108,7 @@ function ProfilePage() {
   const navigation = useNavigation<ProfileStackNavigationProp<'ProfileMain'>>();
   const { width: windowWidth } = useWindowDimensions();
   const contentPadding = Math.max(16, Math.round(windowWidth * 0.048));
-  const chartWidth =
-    windowWidth - Math.max(12, contentPadding * 1.5) * 2;
+  const chartWidth = windowWidth - Math.max(12, contentPadding * 1.5) * 2;
   const chartHeight = Math.max(188, Math.round(windowWidth * 0.52));
   const chartStrokeWidth = Math.max(2, Math.round(windowWidth * 0.008));
   const chartDotRadius = Math.max(3, Math.round(windowWidth * 0.01));

--- a/src/pages/achievement/RankingTab.tsx
+++ b/src/pages/achievement/RankingTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -10,6 +10,7 @@ import {
   ScrollView,
 } from 'react-native';
 import { styles } from '@styles/Achievement_Ranking.styles';
+import { useFocusEffect } from '@react-navigation/native';
 import { getDailyStepRanking } from '@api/rankingApi';
 import { DailyStepRankingResponse } from 'types/ranking';
 import { useSelector } from 'react-redux';
@@ -35,24 +36,34 @@ function RankingTab() {
     (state: RootState) => state.user.profileImageUrl
   );
 
-  useEffect(() => {
-    const fetchRanking = async () => {
-      try {
-        setLoading(true);
-        const data = await getDailyStepRanking({
-          gender: rankingFilter,
-        });
-        setRankingData({
-          topRankings: data.topRankings,
-          myRanking: data.myRanking,
-        });
-      } catch (e) {
-        console.log('랭킹 로드 실패', e);
-      } finally {
-        setLoading(false);
-      }
-    };
+  const fetchRanking = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await getDailyStepRanking({ gender: rankingFilter });
+      setRankingData({
+        topRankings: data.topRankings,
+        myRanking: data.myRanking,
+      });
+    } catch (e) {
+      console.log('랭킹 로드 실패', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [rankingFilter]);
 
+  const isFirstFocus = useRef(true);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (isFirstFocus.current) {
+        isFirstFocus.current = false;
+        return;
+      }
+      fetchRanking();
+    }, [fetchRanking])
+  );
+
+  useEffect(() => {
     fetchRanking();
   }, [rankingFilter]);
 
@@ -127,7 +138,7 @@ function RankingTab() {
                 rank={index + 1}
                 nickname={item.nickname}
                 dailyStepCount={item.score}
-                profileImageUrl={item.profileImageUrl}
+                profileImageUrl={item.userId === myUserId ? myProfileImageUrl : item.profileImageUrl}
                 isTop3={index < 3}
                 highlight={item.userId === myUserId}
               />
@@ -150,7 +161,7 @@ function RankingTab() {
             rank={rankingData.myRanking?.rank ?? 0}
             nickname='나'
             dailyStepCount={rankingData.myRanking?.score ?? 0}
-            profileImageUrl={rankingData.myRanking?.profileImageUrl ?? myProfileImageUrl}
+            profileImageUrl={myProfileImageUrl}
             highlight={true}
           />
         </View>

--- a/src/styles/MainPage.styles.ts
+++ b/src/styles/MainPage.styles.ts
@@ -94,6 +94,8 @@ export default StyleSheet.create({
   progressContainer: {
     height: PROGRESS_CONTAINER_HEIGHT,
     marginBottom: CONTENT_MARGIN_BOTTOM,
+    zIndex: 1,
+    elevation: 1,
   },
   progressRow: {
     paddingHorizontal: Spacing.lg,

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -11,7 +11,13 @@ export type UserUpdateRequest = {
   targetWeightKg?: number;
   targetPbf?: number;
   targetStepCount?: number;
-  profileImageUrl?: string;
+  profileImageKey?: string;
+};
+
+export type ProfileImageHistoryItem = {
+  imageKey: string;
+  presignedUrl: string;
+  isCurrent: boolean;
 };
 
 export type PetUpdateRequest = {


### PR DESCRIPTION
## 🚀 어떤 변경사항이 있나요?
- 프로필 이미지 이력 관리를 로컬에서 서버 API 기반으로 전환
- ProfileAvatar: 이미지 URL 변경 시 실패 상태(imageFailed) 초기화되지 않던 버그 수정
- RankingTab: 탭 진입 시 useFocusEffect + useEffect 중복 API 호출 제거, 포커스 시 자동 새로고침 추가, 내 프로필 이미지
   Redux 값으로 즉시 반영
- 미션 목록 가로 스크롤 시 펫 Pressable이 오인식되던 버그 수정 (progressContainer zIndex/elevation 추가)

## 📋 체크리스트 (Checklist)

- [ ] PR 목표 달성 여부

- [ ] 코드 리뷰를 위한 중요 사항 주석/설명 추가

- [ ] 코딩 컨벤션 준수

- [ ] 테스트 케이스 작성/수정 (필요 시)

- [ ] 스크린샷/GIF 첨부 (UI 변경 있는 경우)

<br>

## 🔗 관련 이슈 (Related Issues)

- 이 PR이 해결하는 이슈 또는 작업이 있는 경우, 여기에 남겨주세요.

- 예시 : Closes #123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 서버 기반 프로필 이미지 이력 지원 — 과거 업로드된 이미지 목록에서 선택 가능하며 썸네일 표시

* **버그 수정**
  * 프로필 아바타가 새 이미지로 정상 재시도/재로드되도록 개선

* **개선 사항**
  * 이미지 선택 저장 후 이력 최신화 및 현재 이미지 반영
  * 랭킹 탭에서 내 프로필 이미지 일관 표시 및 페이지 복귀 시 자동 새로고침
<!-- end of auto-generated comment: release notes by coderabbit.ai -->