### PR TITLE
fix: 릴리즈에서 API 통신 안되는 문제 해결 (HTTP 허용), AndroidManifest에 usesClearetex…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
 
     <application
       android:name=".MainApplication"
-      android:usesCleartextTraffic="true"
+      android:networkSecurityConfig="@xml/network_security_config"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
 
     <application
       android:name=".MainApplication"
+      android:usesCleartextTraffic="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">34.64.91.149</domain>
+    </domain-config>
+
+</network-security-config>

--- a/src/shared/constants/profileIcons.ts
+++ b/src/shared/constants/profileIcons.ts
@@ -1,5 +1,5 @@
 const S3_BASE =
-  'https://slimpet-bucket.s3.ap-northeast-2.amazonaws.com/profile-presets';
+  'https://fitpet-bucket.s3.ap-northeast-2.amazonaws.com/profile-presets';
 
 export const DEFAULT_PROFILE_URL = `${S3_BASE}/image_01.png`;
 


### PR DESCRIPTION
…tTraffic = true 추가

## 🚀 어떤 변경사항이 있나요?
1. 릴리즈 환경에서 특정 API(서버) HTTP 통신 허용을 위해 network_security_config 적용하였습니다. 현재는 34.64.91.149만 허용되며, 추후 HTTPS 적용이 필요할 것으로 보입니다.

2. S3 버킷 명 변경이 불가능하여 fitpet -> slimpet -> fitpet (현재) 형태로 재변경하였습니다.

## 📋 체크리스트 (Checklist)

- [ ] PR 목표 달성 여부

- [ ] 코드 리뷰를 위한 중요 사항 주석/설명 추가

- [ ] 코딩 컨벤션 준수

- [ ] 테스트 케이스 작성/수정 (필요 시)

- [ ] 스크린샷/GIF 첨부 (UI 변경 있는 경우)

<br>

## 🔗 관련 이슈 (Related Issues)

- 이 PR이 해결하는 이슈 또는 작업이 있는 경우, 여기에 남겨주세요.

- 예시 : Closes #123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 애플리케이션이 HTTP(암호화되지 않은) 네트워크 트래픽을 허용하도록 설정이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->