### PR TITLE
fix: Android debug 빌드 Metro cleartext 허용

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -3,7 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:networkSecurityConfig="@xml/debug_network_security_config"
         android:usesCleartextTraffic="true"
+        tools:replace="android:networkSecurityConfig,android:usesCleartextTraffic"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning"/>
 </manifest>

--- a/android/app/src/debug/res/xml/debug_network_security_config.xml
+++ b/android/app/src/debug/res/xml/debug_network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## 🚀 어떤 변경사항이 있나요?

- Android debug 빌드에서 Metro dev server 접속에 필요한 cleartext 도메인을 허용했습니다. <br>
- `localhost`, `127.0.0.1`, `10.0.2.2`를 debug 전용 network security config에 추가했습니다. <br>
- 운영/release 빌드의 network security 설정에는 영향을 주지 않도록 `src/debug`에만 적용했습니다. <br>

## 📋 체크리스트 (Checklist)

- [x] PR 목표 달성 여부

- [x] 코드 리뷰를 위한 중요 사항 주석/설명 추가

- [x] 코딩 컨벤션 준수

- [x] 테스트 케이스 작성/수정 (필요 시)

- [ ] 스크린샷/GIF 첨부 (UI 변경 있는 경우)

<br>

## 🔗 관련 이슈 (Related Issues)

- Android debug 빌드에서 Metro 번들 로드 시 `CLEARTEXT communication to 10.0.2.2 not permitted by network security policy`가 발생하던 문제를 해결합니다.
- 검증: `npx react-native run-android --no-packager` 빌드/설치 성공 및 앱 정상 진입 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- 디버그 빌드의 네트워크 보안 설정을 개선했습니다. 로컬 개발 및 테스트 환경에서 안정적으로 작동하도록 네트워크 보안 정책을 재구성했으며, 개발 목적의 보안 설정을 추가로 구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->